### PR TITLE
Deploy video upload feature with OAuth 2.0 support and v2 API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ X-Scheduler now supports uploading videos to Twitter using the chunked upload pr
     docker exec <container_id_or_name> python -m src.main --setup-oauth
     ```
     This starts a temporary web server (usually on port 5000) to guide you through the browser-based X authorization flow. Follow the prompts in your terminal and browser. Credentials (refresh tokens) are securely stored (e.g., in DynamoDB for AWS deployments).
+    
+    > **Important**: The OAuth flow must request the `media.write` scope in addition to the standard scopes. This is critical for video uploads and prevents 403 Forbidden errors. The application handles this automatically, but custom implementations must include this scope.
 
 2. **Providing Videos:**
     * **Direct Upload (Testing):** Use the `--upload-video` flag with a local path:

--- a/deploy/aws/cloudformation.yaml
+++ b/deploy/aws/cloudformation.yaml
@@ -46,7 +46,9 @@ Conditions:
 
 
 Mappings:
-  # Add mappings if needed, e.g., Region specific AMIs if not using SSM Parameter Store lookup
+  RegionMap:
+    us-east-1:
+      AMI: ami-0c7217cdde317cfec # Example AMI ID - update as needed
 
 Resources:
   # --- IAM Role and Instance Profile ---


### PR DESCRIPTION
## Deploy Branch for Video Upload Feature

This PR creates a specific deployment branch for the video upload functionality. It includes:

1. All changes from the video-upload branch (#3)
2. Additional documentation in README about the required `media.write` OAuth scope
3. Fixed CloudFormation template for AWS deployment

### Key Changes:
- OAuth 2.0 PKCE authentication flow with required `media.write` scope
- Migration from v1.1 to v2 API endpoints for media uploads
- Chunked video upload support with proper status polling
- Enhanced error handling and logging
- Documentation improvements

This dedicated deployment branch is intended to be used for AWS deployments and can be kept in sync with main as new features are added.

### How to deploy:
1. Once merged, the code can be deployed to AWS using the `deploy-to-aws.sh` script
2. Users will need to re-authenticate to grant the new `media.write` scope